### PR TITLE
fix rgbToYuv method

### DIFF
--- a/app/src/main/java/team/birdhead/rgb2yuv/converter/JavaConverter.java
+++ b/app/src/main/java/team/birdhead/rgb2yuv/converter/JavaConverter.java
@@ -28,7 +28,7 @@ public class JavaConverter implements Converter {
                     yuv[uvIndex++] = (byte) Math.max(0, Math.min(255, u));
                 }
 
-                rgbIndex += 4;
+                rgbIndex += 3;
             }
         }
     }


### PR DESCRIPTION
RGBcolor pixel format takes 3 bytes instead of 4bytes.  May be you are dealing RGBA color space?